### PR TITLE
Fix PHP 8.1 deprecation warnings

### DIFF
--- a/site/models/rules/phocaguestbookemail.php
+++ b/site/models/rules/phocaguestbookemail.php
@@ -38,7 +38,7 @@ class JFormRulePhocaguestbookEmail extends EmailRule
 		}
 
 		//BANNED EMAIL
-		$banned = $params->get('banned_email');
+		$banned = $params->get('banned_email', '');
 		foreach(explode(';', $banned) as $item){
 			if (trim($item) != '')
 			if (StringHelper::stristr($item, $value) !== false){

--- a/site/views/guestbook/view.html.php
+++ b/site/views/guestbook/view.html.php
@@ -266,7 +266,7 @@ class PhocaguestbookViewGuestbook extends HtmlView
 			$document->addCustomTag('<style type="text/css"> .pgb-comment:after { '."\n\t".'content: "'.Text::_('COM_PHOCAGUESTBOOK_CSS_COMMENT').'";'."\n".'}</style>');
 		}
 		//Escape strings for HTML output
-		$this->pageclass_sfx = htmlspecialchars($params->get('pageclass_sfx'));
+		$this->pageclass_sfx = htmlspecialchars($params->get('pageclass_sfx', ''));
 
 
 		// Create a shortcut


### PR DESCRIPTION
This PR fixes the following 2 PHP 8.1. deprecated warnings;
- When loading guestbook in frontend: Deprecated null parameter 1 for htmlspecialchars in view.html.php
- When posting with email address:  Deprecated null parameter 2 for explode in phocaguestbookemail.php

There are 2 more PHP 8.1 deprecations but they are caused by the HTML Purifier. Possibly they could just be fixed by updating it to latest version 4.16.0 from 12 days ago, see https://github.com/ezyang/htmlpurifier/releases . These deprecations are:
- Return type of HTMLPurifier_StringHash::offsetGet($index) should either be compatible with ArrayObject::offsetGet(mixed $key): mixed, or the #[\\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in /home/richard/lamp/public_html/test-1/components/com_phocaguestbook/assets/library/HTMLPurifier.standalone.php on line 8441
- Return type of HTMLPurifier_PropertyListIterator::accept() should either be compatible with FilterIterator::accept(): bool, or the #[\\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in /home/richard/lamp/public_html/test-1/components/com_phocaguestbook/assets/library/HTMLPurifier.standalone.php on line 8323